### PR TITLE
RulesEngine Class Name Clash in Subsystem-Arm

### DIFF
--- a/subsystem-arm/implementations/hand/rules-engine.hpp
+++ b/subsystem-arm/implementations/hand/rules-engine.hpp
@@ -5,7 +5,7 @@
 
 namespace sjsu::arm
 {
-    class RulesEngine
+    class HandRulesEngine
     {
     public:
         static constexpr int kMaxFingerAngle = 180;
@@ -15,18 +15,41 @@ namespace sjsu::arm
         {
             if (!heartbeat_.IsSyncedWithMissionControl(commands.heartbeat_count))
             {
-                sjsu::LogInfo("Hand was unsynced, holding previous state!");
+                sjsu::LogWarning("Hand was unsynced, holding previous state!");
                 return previous_commands;
             }
             if (!commands.is_operational)
             {
-                sjsu::LogInfo("Hand is not operational... holding previous state!");
+                sjsu::LogWarning("Hand is not operational... holding previous state!");
                 return previous_commands;
             }
-            if (commands.index_angle > 180) // WIP: Potential issue with desyncing and previous commands not being clamped
+            
+            if (commands.thumb_angle > kMaxFingerAngle || commands.thumb_angle < kMinFingerAngle)
             {
+                sjsu::LogWarning("Thumb angle is out of bounds... clamping to limit");
+                commands.thumb_angle = std::clamp(commands.thumb_angle, kMinFingerAngle, kMaxFingerAngle);
+            }
+            if (commands.index_angle > kMaxFingerAngle || commands.index_angle < kMinFingerAngle)
+            {
+                sjsu::LogWarning("Index finger angle is out of bounds... clamping to limit");
                 commands.index_angle = std::clamp(commands.index_angle, kMinFingerAngle, kMaxFingerAngle);
             }
+            if (commands.middle_angle > kMaxFingerAngle || commands.middle_angle < kMinFingerAngle)
+            {
+                sjsu::LogWarning("Middle finger angle is out of bounds... clamping to limit");
+                commands.middle_angle = std::clamp(commands.middle_angle, kMinFingerAngle, kMaxFingerAngle);
+            }
+            if (commands.ring_angle > kMaxFingerAngle || commands.ring_angle < kMinFingerAngle)
+            {
+                sjsu::LogWarning("Ring finger angle is out of bounds... clamping to limit");
+                commands.ring_angle = std::clamp(commands.ring_angle, kMinFingerAngle, kMaxFingerAngle);
+            }
+            if (commands.pinky_angle > kMaxFingerAngle || commands.pinky_angle < kMinFingerAngle)
+            {
+                sjsu::LogWarning("Pinky finger angle is out of bounds... clamping to limit");
+                commands.pinky_angle = std::clamp(commands.pinky_angle, kMinFingerAngle, kMaxFingerAngle);
+            }
+
             heartbeat_.IncrementHeartbeatCount();
             previous_commands = commands;
             return commands;

--- a/subsystem-arm/implementations/joints/rules-engine.hpp
+++ b/subsystem-arm/implementations/joints/rules-engine.hpp
@@ -1,12 +1,12 @@
 #pragma once
-
+#include "utility/log.hpp"
 #include "../dto/arm-dto.hpp"
 #include "../common/heartbeat.hpp"
 
 namespace sjsu::arm
 {
 
-    class RulesEngine
+    class JointsRulesEngine
     {
         public:
         static constexpr int kMaxShoulderAngle = 90;

--- a/subsystem-arm/test/hand-rules-engine_test.cpp
+++ b/subsystem-arm/test/hand-rules-engine_test.cpp
@@ -7,7 +7,7 @@ namespace sjsu::arm
 {
     TEST_CASE("Hand Rules Engine")
     {
-        RulesEngine engine;
+        HandRulesEngine engine;
         hand_arguments commands;
         SECTION("should validate heartbeat logic")
         {
@@ -43,12 +43,21 @@ namespace sjsu::arm
             CHECK_NE(commands.index_angle, response.index_angle);
         }
 
-        SECTION("should validate max and min finger angles")
+        SECTION("should validate max and min finger angles clamping")
         {
-            commands.is_operational = 1;
+            commands.is_operational = -1;
+            commands.thumb_angle = -180;
             commands.index_angle = 200;
+            commands.middle_angle = -90;
+            commands.ring_angle = 190;
+            commands.pinky_angle = 181;
+
             hand_arguments response = engine.ValidateCommands(commands);
+            CHECK_NE(commands.thumb_angle, response.thumb_angle);
             CHECK_NE(commands.index_angle, response.index_angle);
+            CHECK_NE(commands.middle_angle, response.middle_angle);
+            CHECK_NE(commands.ring_angle, response.ring_angle);
+            CHECK_NE(commands.pinky_angle, response.pinky_angle);
         }
     }
 }


### PR DESCRIPTION
Finished the Hand rules engine, and implemented working test cases. Also renamed the Hand and Joint rules engine to prevent name clashing