### PR TITLE
Tri wheel router refactor

### DIFF
--- a/subsystem-drive/implementations/tri-wheel-router.hpp
+++ b/subsystem-drive/implementations/tri-wheel-router.hpp
@@ -73,8 +73,6 @@ namespace sjsu::drive
         /// At the moment, homing is where the legs turn on so we just calculate the initial encoder positions. ***Must be called in main
         void HomeLegs()
         {
-            int not_homed = 1;
-
             motor_feedback angle_verification;
 
             while (WheelNotZeroDoThis(left_) | WheelNotZeroDoThis(right_) | WheelNotZeroDoThis(back_))

--- a/subsystem-drive/implementations/tri-wheel-router.hpp
+++ b/subsystem-drive/implementations/tri-wheel-router.hpp
@@ -81,27 +81,12 @@ namespace sjsu::drive
             {
                 //This loops until all of the wheels are zeroed and/or homed
             }
-            while (left_.magnet_.Read() == not_homed || right_.magnet_.Read() == not_homed || back_.magnet_.Read() == not_homed)
+            while (WheelNotHomeDoThis(left_) || WheelNotHomeDoThis(right_)|| WheelNotHomeDoThis(back_))
             {
                 sjsu::LogInfo("HomingPins L = %d\t R = %d\t B = %d", left_.magnet_.Read(), right_.magnet_.Read(), back_.magnet_.Read()); //sigma
-                if (left_.magnet_.Read() == not_homed)
-                {
-                    left_.wheel_offset_++;
-                    left_.steer_motor_.SetAngle(units::angle::degree_t(left_.wheel_offset_, 2_rpm));
-                }
 
-                if (right_.magnet_.Read() == not_homed)
-                {
-                    right_.wheel_offset_++;
-                    right_.steer_motor_.SetAngle(units::angle::degree_t(right_.wheel_offset_, 2_rpm));
-                }
-
-                if (back_.magnet_.Read() == not_homed)
-                {
-                    back_.wheel_offset_++;
-                    back_.steer_motor_.SetAngle(units::angle::degree_t(back_.wheel_offset_, 2_rpm));
-                }
                 sjsu::LogInfo("b = %d\tr = %d\tl = %d", back_.wheel_offset_, right_.wheel_offset_, left_.wheel_offset_);
+
                 angle_verification = GetMotorFeedback();
                 while (angle_verification.left_steer_speed != 0_rpm || angle_verification.right_steer_speed != 0_rpm || angle_verification.back_steer_speed != 0_rpm)
                 {
@@ -144,8 +129,19 @@ namespace sjsu::drive
             }
         }
 
-        bool WheelNotHome (leg* leg_) {
+        bool WheelNotHomeDoThis (leg& leg_) {
+            int not_homed = 1;
 
+            if (leg_.magnet_.Read() == not_homed)
+            {
+                leg_.wheel_offset_++;
+                leg_.steer_motor_.SetAngle(units::angle::degree_t(leg_.wheel_offset_, 2_rpm));
+                return true;
+            }
+            else 
+            {
+            return false;
+            }
         }
 
         // member variables

--- a/subsystem-drive/implementations/tri-wheel-router.hpp
+++ b/subsystem-drive/implementations/tri-wheel-router.hpp
@@ -77,9 +77,9 @@ namespace sjsu::drive
 
             motor_feedback angle_verification;
 
-            while (WheelNotZero(left_) || WheelNotZero(right_) || WheelNotZero(back_))
+            while (WheelNotZeroDoThis(left_) || WheelNotZeroDoThis(right_) || WheelNotZeroDoThis(back_))
             {
-                //Intentionally left empty
+                //This loops until all of the wheels are zeroed and/or homed
             }
             while (left_.magnet_.Read() == not_homed || right_.magnet_.Read() == not_homed || back_.magnet_.Read() == not_homed)
             {
@@ -120,7 +120,7 @@ namespace sjsu::drive
         }
 
     private:
-        bool WheelNotZero(leg& leg_) {
+        bool WheelNotZeroDoThis(leg& leg_) {
             int not_homed = 1;
             //This leg is NOT at zero
             if ((common::RmdEncoder::CalcEncoderPositions(leg_.steer_motor_) >= 0.01f) ||  common::RmdEncoder::CalcEncoderPositions(leg_.steer_motor_) <= -0.01f) 
@@ -142,6 +142,10 @@ namespace sjsu::drive
                 //This wheel is at zero
                 return false;
             }
+        }
+
+        bool WheelNotHome (leg* leg_) {
+
         }
 
         // member variables

--- a/subsystem-drive/implementations/tri-wheel-router.hpp
+++ b/subsystem-drive/implementations/tri-wheel-router.hpp
@@ -21,6 +21,7 @@ namespace sjsu::drive
             sjsu::RmdX &steer_motor_;
             sjsu::RmdX &drive_motor_;
             sjsu::Gpio &magnet_;
+            int wheel_offset_;
         };
 
         TriWheelRouter(leg right, leg left, leg back) : left_(left), back_(back), right_(right)
@@ -41,19 +42,22 @@ namespace sjsu::drive
             left_.magnet_.SetAsInput();
             right_.magnet_.SetAsInput();
             back_.magnet_.SetAsInput();
+            left_.wheel_offset_ = 0;
+            right_.wheel_offset_ = 0;
+            back_.wheel_offset_ = 0;
         }
 
         tri_wheel_router_arguments SetLegArguments(tri_wheel_router_arguments tri_wheel_arguments)
         {
-            left_.steer_motor_.SetAngle(units::angle::degree_t(-tri_wheel_arguments.left.steer.angle + left_wheel_offset),
+            left_.steer_motor_.SetAngle(units::angle::degree_t(-tri_wheel_arguments.left.steer.angle + left_.wheel_offset),
                                         units::angular_velocity::revolutions_per_minute_t(tri_wheel_arguments.left.steer.speed));
             left_.drive_motor_.SetSpeed(units::angular_velocity::revolutions_per_minute_t(tri_wheel_arguments.left.hub.speed));
 
-            right_.steer_motor_.SetAngle(units::angle::degree_t(-tri_wheel_arguments.right.steer.angle + right_wheel_offset),
+            right_.steer_motor_.SetAngle(units::angle::degree_t(-tri_wheel_arguments.right.steer.angle + right_.wheel_offset),
                                          units::angular_velocity::revolutions_per_minute_t(tri_wheel_arguments.right.steer.speed));
             right_.drive_motor_.SetSpeed(units::angular_velocity::revolutions_per_minute_t(tri_wheel_arguments.right.hub.speed));
 
-            back_.steer_motor_.SetAngle(units::angle::degree_t(-tri_wheel_arguments.back.steer.angle + back_wheel_offset),
+            back_.steer_motor_.SetAngle(units::angle::degree_t(-tri_wheel_arguments.back.steer.angle + back_wheel_.offset),
                                         units::angular_velocity::revolutions_per_minute_t(tri_wheel_arguments.back.steer.speed));
             back_.drive_motor_.SetSpeed(units::angular_velocity::revolutions_per_minute_t(tri_wheel_arguments.back.hub.speed));
 
@@ -93,22 +97,22 @@ namespace sjsu::drive
                 sjsu::LogInfo("HomingPins L = %d\t R = %d\t B = %d", left_.magnet_.Read(), right_.magnet_.Read(), back_.magnet_.Read()); //sigma
                 if (left_.magnet_.Read() == not_homed)
                 {
-                    left_wheel_offset++;
-                    left_.steer_motor_.SetAngle(units::angle::degree_t(left_wheel_offset, 2_rpm));
+                    left_.wheel_offset++;
+                    left_.steer_motor_.SetAngle(units::angle::degree_t(left_.wheel_offset, 2_rpm));
                 }
 
                 if (right_.magnet_.Read() == not_homed)
                 {
-                    right_wheel_offset++;
-                    right_.steer_motor_.SetAngle(units::angle::degree_t(right_wheel_offset, 2_rpm));
+                    right_.wheel_offset++;
+                    right_.steer_motor_.SetAngle(units::angle::degree_t(right_.wheel_offset, 2_rpm));
                 }
 
                 if (back_.magnet_.Read() == not_homed)
                 {
-                    back_wheel_offset++;
-                    back_.steer_motor_.SetAngle(units::angle::degree_t(back_wheel_offset, 2_rpm));
+                    back_.wheel_offset++;
+                    back_.steer_motor_.SetAngle(units::angle::degree_t(back_.wheel_offset, 2_rpm));
                 }
-                sjsu::LogInfo("b = %d\tr = %d\tl = %d", back_wheel_offset, right_wheel_offset, left_wheel_offset);
+                sjsu::LogInfo("b = %d\tr = %d\tl = %d", back_.wheel_offset, right_.wheel_offset, left_.wheel_offset);
                 angle_verification = GetMotorFeedback();
                 while (angle_verification.left_steer_speed != 0_rpm || angle_verification.right_steer_speed != 0_rpm || angle_verification.back_steer_speed != 0_rpm)
                 {
@@ -128,9 +132,6 @@ namespace sjsu::drive
 
     private:
         // member variables
-        int16_t left_wheel_offset = 0;
-        int16_t right_wheel_offset = 0;
-        int16_t back_wheel_offset = 0;
 
         leg left_;
         leg back_;

--- a/subsystem-drive/implementations/tri-wheel-router.hpp
+++ b/subsystem-drive/implementations/tri-wheel-router.hpp
@@ -77,11 +77,11 @@ namespace sjsu::drive
 
             motor_feedback angle_verification;
 
-            while (WheelNotZeroDoThis(left_) || WheelNotZeroDoThis(right_) || WheelNotZeroDoThis(back_))
+            while (WheelNotZeroDoThis(left_) | WheelNotZeroDoThis(right_) | WheelNotZeroDoThis(back_))
             {
                 //This loops until all of the wheels are zeroed and/or homed
             }
-            while (WheelNotHomeDoThis(left_) || WheelNotHomeDoThis(right_)|| WheelNotHomeDoThis(back_))
+            while (WheelNotHomeDoThis(left_) | WheelNotHomeDoThis(right_) | WheelNotHomeDoThis(back_))
             {
                 sjsu::LogInfo("HomingPins L = %d\t R = %d\t B = %d", left_.magnet_.Read(), right_.magnet_.Read(), back_.magnet_.Read()); //sigma
 

--- a/subsystem-drive/implementations/tri-wheel-router.hpp
+++ b/subsystem-drive/implementations/tri-wheel-router.hpp
@@ -125,9 +125,9 @@ namespace sjsu::drive
             //This leg is NOT at zero
             if ((common::RmdEncoder::CalcEncoderPositions(leg_.steer_motor_) >= 0.01f) ||  common::RmdEncoder::CalcEncoderPositions(leg_.steer_motor_) <= -0.01f) 
             {
-                if (left_.magnet_.Read() == not_homed)
+                if (leg_.magnet_.Read() == not_homed)
                 {
-                    left_.steer_motor_.SetAngle(0_deg, 2_rpm);
+                    leg_.steer_motor_.SetAngle(0_deg, 2_rpm);
                     //This wheel is NOT at zero
                     return true;
                 }


### PR DESCRIPTION
tri-wheel-router has been refactored in several ways:
- Zeroing logic moved to a private function.
- Homing logic moved to a private function.
- Wheel offsets added to leg struct and removed from TriWheelRouter class
All changes have been tested and validated on the rover.

Issue: https://github.com/SJSURoboticsTeam/urc-control-systems-2022/issues/197